### PR TITLE
socrata-thirdparty-utils and simple-arm dependency update.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,10 +9,10 @@ resolvers ++= Seq(
 
 libraryDependencies ++= Seq(
   "ch.qos.logback"           % "logback-classic"          % "1.1.2",
-  "com.rojoma"              %% "simple-arm-v2"            % "2.0.0",
+  "com.rojoma"              %% "simple-arm-v2"            % "2.1.0",
   "com.socrata"             %% "socrata-http-client"      % "3.0.1",
   "com.socrata"             %% "socrata-http-jetty"       % "3.0.1",
-  "com.socrata"             %% "socrata-thirdparty-utils" % "2.6.3",
+  "com.socrata"             %% "socrata-thirdparty-utils" % "3.0.0",
   "com.typesafe"             % "config"                   % "1.2.1",
   "commons-codec"            % "commons-codec"            % "1.10",
   "commons-io"               % "commons-io"               % "2.4",

--- a/build.sbt
+++ b/build.sbt
@@ -10,8 +10,8 @@ resolvers ++= Seq(
 libraryDependencies ++= Seq(
   "ch.qos.logback"           % "logback-classic"          % "1.1.2",
   "com.rojoma"              %% "simple-arm-v2"            % "2.1.0",
-  "com.socrata"             %% "socrata-http-client"      % "3.0.1",
-  "com.socrata"             %% "socrata-http-jetty"       % "3.0.1",
+  "com.socrata"             %% "socrata-http-client"      % "3.2.0",
+  "com.socrata"             %% "socrata-http-jetty"       % "3.2.0",
   "com.socrata"             %% "socrata-thirdparty-utils" % "3.0.0",
   "com.typesafe"             % "config"                   % "1.2.1",
   "commons-codec"            % "commons-codec"            % "1.10",

--- a/src/main/scala/com.socrata.tileserver/exceptions/InvalidGeoJsonException.scala
+++ b/src/main/scala/com.socrata.tileserver/exceptions/InvalidGeoJsonException.scala
@@ -3,7 +3,8 @@ package com.socrata.tileserver.exceptions
 import scala.util.control.NoStackTrace
 
 import com.rojoma.json.v3.ast.JValue
+import com.rojoma.json.v3.codec.DecodeError
 
-case class InvalidGeoJsonException(jValue: JValue) extends NoStackTrace {
-  override val getMessage = s"Invalid geo-json: ${jValue.toString}"
+case class InvalidGeoJsonException(jValue: JValue, error: DecodeError) extends NoStackTrace {
+  override val getMessage = s"Unable to parse geo-json: ${error.english}, while parsing: ${jValue.toString}"
 }

--- a/src/test/scala/com.socrata.tileserver/TestBase.scala
+++ b/src/test/scala/com.socrata.tileserver/TestBase.scala
@@ -6,7 +6,6 @@ import org.scalatest.prop.PropertyChecks
 
 import com.rojoma.json.v3.ast.JString
 import com.rojoma.json.v3.codec.JsonEncode.toJValue
-import com.rojoma.json.v3.conversions._
 import com.vividsolutions.jts.geom.{Coordinate, GeometryFactory, Point}
 
 import com.socrata.thirdparty.geojson.FeatureJson
@@ -21,8 +20,8 @@ trait TestBase
 
   def fJson(pt: (Int, Int),
             attributes: Map[String, String] = Map.empty): FeatureJson = {
-    val attributesV2 = attributes map { case (k, v) => (k, toJValue(v).toV2) }
-    FeatureJson(attributesV2, point(pt))
+    val attributesAsJvalues = attributes map { case (k, v) => (k, toJValue(v)) }
+    FeatureJson(attributesAsJvalues, point(pt))
   }
 
   def feature(pt: (Int, Int),

--- a/src/test/scala/com.socrata.tileserver/mocks/SeqResponse.scala
+++ b/src/test/scala/com.socrata.tileserver/mocks/SeqResponse.scala
@@ -16,7 +16,7 @@ class SeqResponse(seq: Seq[FeatureJson]) extends EmptyResponse {
   override val resultCode = ScOk
 
   override def toString: String =
-    encode(FeatureCollectionJson(seq)).toV3.toString.replaceAll("\\s*", "")
+    encode(FeatureCollectionJson(seq)).toString.replaceAll("\\s*", "")
 
   override def inputStream(maxBetween: Long): InputStream with Acknowledgeable =
     StringInputStream(toString)


### PR DESCRIPTION
This gets past the rojoma.json.v3 hump for a number of things and sets
the stage for the next step, which is updating socrata-http so it doesn't cause
responses to vary on user agent.