### PR TITLE
Pull points from Core using .soqlpack when possible

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,8 @@ scalaVersion := "2.10.4"
 
 resolvers ++= Seq(
   "socrata maven" at "https://repository-socrata-oss.forge.cloudbees.com/release",
-  "ecc" at "https://github.com/ElectronicChartCentre/ecc-mvn-repo/raw/master/releases"
+  "ecc" at "https://github.com/ElectronicChartCentre/ecc-mvn-repo/raw/master/releases",
+  "velvia maven" at "http://dl.bintray.com/velvia/maven"
 )
 
 libraryDependencies ++= Seq(
@@ -17,6 +18,7 @@ libraryDependencies ++= Seq(
   "commons-codec"            % "commons-codec"            % "1.10",
   "commons-io"               % "commons-io"               % "2.4",
   "no.ecc.vectortile"        % "java-vector-tile"         % "1.0.1",
+  "org.velvia"              %% "msgpack4s"                % "0.4.2",
   "org.apache.curator"       % "curator-x-discovery"      % "2.7.0"
 )
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -8,7 +8,7 @@ com.socrata {
 
     threadpool {
       min-threads = 3
-      max-threads = 5
+      max-threads = 30
       idle-timeout = 30 s
       queue-length = 100
     }

--- a/src/main/scala/com.socrata.tileserver/exceptions/InvalidSoqlPackException.scala
+++ b/src/main/scala/com.socrata.tileserver/exceptions/InvalidSoqlPackException.scala
@@ -3,5 +3,8 @@ package com.socrata.tileserver.exceptions
 import scala.util.control.NoStackTrace
 
 case class InvalidSoqlPackException(headers: Map[String, Any]) extends NoStackTrace {
-  override val getMessage = s"No geometry present or other header error: $headers"
+  override val getMessage = {
+    if (headers.isEmpty) "Unable to parse binary stream into SoQLPack/MessagePack records"
+    else                 s"No geometry present or other header error: $headers"
+  }
 }

--- a/src/main/scala/com.socrata.tileserver/exceptions/InvalidSoqlPackException.scala
+++ b/src/main/scala/com.socrata.tileserver/exceptions/InvalidSoqlPackException.scala
@@ -1,0 +1,7 @@
+package com.socrata.tileserver.exceptions
+
+import scala.util.control.NoStackTrace
+
+case class InvalidSoqlPackException(headers: Map[String, Any]) extends NoStackTrace {
+  override val getMessage = s"No geometry present or other header error: $headers"
+}

--- a/src/main/scala/com.socrata.tileserver/exceptions/InvalidSoqlPackException.scala
+++ b/src/main/scala/com.socrata.tileserver/exceptions/InvalidSoqlPackException.scala
@@ -3,8 +3,9 @@ package com.socrata.tileserver.exceptions
 import scala.util.control.NoStackTrace
 
 case class InvalidSoqlPackException(headers: Map[String, Any]) extends NoStackTrace {
-  override val getMessage = {
-    if (headers.isEmpty) "Unable to parse binary stream into SoQLPack/MessagePack records"
-    else                 s"No geometry present or other header error: $headers"
+  override val getMessage = if (headers.isEmpty) {
+    "Unable to parse binary stream into SoQLPack/MessagePack records"
+  } else {
+    s"No geometry present or other header error: $headers"
   }
 }

--- a/src/main/scala/com.socrata.tileserver/services/TileService.scala
+++ b/src/main/scala/com.socrata.tileserver/services/TileService.scala
@@ -1,6 +1,7 @@
 package com.socrata.tileserver
 package services
 
+import java.io.DataInputStream
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets.UTF_8
 import javax.servlet.http.HttpServletResponse
@@ -8,14 +9,17 @@ import javax.servlet.http.HttpServletResponse.{SC_NOT_MODIFIED => ScNotModified}
 import javax.servlet.http.HttpServletResponse.{SC_OK => ScOk}
 import scala.util.{Try, Success, Failure}
 
-import com.rojoma.json.v3.ast.JValue
+import com.rojoma.json.v3.ast.{JValue, JNull}
 import com.rojoma.json.v3.codec.JsonEncode.toJValue
 import com.rojoma.json.v3.interpolation._
 import com.rojoma.json.v3.io.JsonReader
 import com.rojoma.json.v3.io.JsonReaderException
 import com.vividsolutions.jts.geom.GeometryFactory
+import com.vividsolutions.jts.io.WKBReader
 import org.apache.commons.io.IOUtils
 import org.slf4j.{Logger, LoggerFactory, MDC}
+import org.velvia.MsgPack
+import org.velvia.MsgPackUtils._
 
 import com.socrata.thirdparty.curator.CuratedServiceClient
 import com.socrata.http.client.{RequestBuilder, Response}
@@ -27,7 +31,7 @@ import com.socrata.http.server.{HttpRequest, HttpResponse, HttpService}
 import com.socrata.thirdparty.geojson.{GeoJson, FeatureCollectionJson, FeatureJson}
 
 import TileService._
-import exceptions.InvalidGeoJsonException
+import exceptions._
 import util.TileEncoder.Feature
 import util.{HeaderFilter, QuadTile, TileEncoder}
 
@@ -43,16 +47,21 @@ case class TileService(client: CuratedServiceClient) extends SimpleResource {
   /** The types (file extensions) supported by this endpoint. */
   val types: Set[String] = Set("pbf", "bpbf", "json", "txt")
 
-  // Call to the underlying service.
-  private[services] def geoJsonQuery(requestId: RequestId,
-                                     req: HttpRequest,
-                                     id: String,
-                                     params: Map[String, String],
-                                     callback: Response => HttpResponse): HttpResponse = {
+  // Call to the underlying service (Core)
+  // Note: this can either pull the points as .geojson or .soqlpack
+  // SoQLPack is binary protocol, much faster and more efficient than GeoJSON
+  // in terms of both performance (~3x) and memory usage (1/10th, or so)
+  private[services] def pointQuery(requestId: RequestId,
+                                   req: HttpRequest,
+                                   id: String,
+                                   params: Map[String, String],
+                                   binaryQuery: Boolean = false,
+                                   callback: Response => HttpResponse): HttpResponse = {
     val headers = HeaderFilter.headers(req)
+    val queryType = if (binaryQuery) "soqlpack" else "geojson"
 
     val jsonReq = { base: RequestBuilder =>
-      val req = base.path(Seq("id", s"$id.geojson")).
+      val req = base.path(Seq("id", s"$id.$queryType")).
         addHeaders(headers).
         addHeader(ReqIdHeader -> requestId).
         query(params).get
@@ -91,6 +100,9 @@ case class TileService(client: CuratedServiceClient) extends SimpleResource {
       OK ~> HeaderFilter.extract(resp) ~> payload
     }
 
+    val isGeoJsonResponse = Response.acceptGeoJson(resp.contentType)
+    val features = if (isGeoJsonResponse) geoJsonFeatures _ else soqlPackFeatures _
+
     lazy val result = resp.resultCode match {
       case ScOk => features(resp).map(createResponse).recover(handleErrors).get
       case ScNotModified => NotModified
@@ -112,11 +124,13 @@ case class TileService(client: CuratedServiceClient) extends SimpleResource {
       val params = augmentParams(req, withinBox, pointColumn)
       val requestId = extractRequestId(req)
 
-      geoJsonQuery(requestId,
-                   req,
-                   identifier,
-                   params,
-                   processResponse(tile, ext))
+      pointQuery(requestId,
+                 req,
+                 identifier,
+                 params,
+                 // Right now soqlpack queries won't work on non-geom columns
+                 !req.queryParameters.contains("$select"),
+                 processResponse(tile, ext))
     } recover {
       case e => fatal("Unknown error", e)
     } get
@@ -192,13 +206,37 @@ object TileService {
   private[services] def extractRequestId(req: HttpRequest): RequestId =
     getFromRequest(req.servletRequest)
 
-  private[services] def features(resp: Response): Try[(JValue, Iterator[FeatureJson])] = {
+  private[services] def geoJsonFeatures(resp: Response): Try[(JValue, Iterator[FeatureJson])] = {
     Try(resp.jValue(Response.acceptGeoJson)) flatMap { jValue =>
       GeoJson.codec.decode(jValue) match {
         case Left(error) => Failure(InvalidGeoJsonException(jValue, error))
         case Right(FeatureCollectionJson(features, _)) => Success(jValue -> features.toIterator)
         case Right(feature: FeatureJson) => Success(jValue -> Iterator.single(feature))
       }
+    }
+  }
+
+  private[services] def soqlPackFeatures(resp: Response): Try[(JValue, Iterator[FeatureJson])] = {
+    val reader = new WKBReader
+    val dis = new DataInputStream(resp.inputStream(Long.MaxValue))
+    try {
+      val headers = MsgPack.unpack(dis, MsgPack.UNPACK_RAW_AS_STRING).asInstanceOf[Map[String, Any]]
+      headers.asInt("geometry_index") match {
+        case geomIndex if geomIndex < 0 => Failure(InvalidSoqlPackException(headers))
+        case geomIndex =>
+          val featureJsonIt = new Iterator[FeatureJson] {
+            def hasNext: Boolean = dis.available > 0
+            def next: FeatureJson = {
+              val row = MsgPack.unpack(dis, 0).asInstanceOf[Seq[Any]]
+              val geom = reader.read(row(geomIndex).asInstanceOf[Array[Byte]])
+              // TODO: parse other columns as properties.  For now just skip it
+              FeatureJson(Map(), geom)
+            }
+          }
+          Success(JNull -> featureJsonIt)
+      }
+    } finally {
+      dis.close()
     }
   }
 

--- a/src/main/scala/com.socrata.tileserver/services/TileService.scala
+++ b/src/main/scala/com.socrata.tileserver/services/TileService.scala
@@ -100,11 +100,11 @@ case class TileService(client: CuratedServiceClient) extends SimpleResource {
       OK ~> HeaderFilter.extract(resp) ~> payload
     }
 
-    val isGeoJsonResponse = Response.acceptGeoJson(resp.contentType)
-    val features = if (isGeoJsonResponse) geoJsonFeatures _ else soqlPackFeatures _
-
     lazy val result = resp.resultCode match {
-      case ScOk => features(resp).map(createResponse).recover(handleErrors).get
+      case ScOk =>
+        val isGeoJsonResponse = Response.acceptGeoJson(resp.contentType)
+        val features = if (isGeoJsonResponse) geoJsonFeatures _ else soqlPackFeatures _
+        features(resp).map(createResponse).recover(handleErrors).get
       case ScNotModified => NotModified
       case _ => echoResponse(resp)
     }

--- a/src/main/scala/com.socrata.tileserver/util/FeatureJsonIterator.scala
+++ b/src/main/scala/com.socrata.tileserver/util/FeatureJsonIterator.scala
@@ -1,0 +1,21 @@
+package com.socrata.tileserver
+package util
+
+import java.io.DataInputStream
+
+import com.socrata.thirdparty.geojson.FeatureJson
+import com.vividsolutions.jts.io.WKBReader
+import org.velvia.MsgPack
+import org.velvia.MsgPackUtils._
+
+class FeatureJsonIterator(reader: WKBReader,
+                          dis: DataInputStream,
+                          geomIndex: Int) extends Iterator[FeatureJson] {
+  def hasNext: Boolean = dis.available > 0
+  def next(): FeatureJson = {
+    val row = MsgPack.unpack(dis, 0).asInstanceOf[Seq[Any]]
+    val geom = reader.read(row(geomIndex).asInstanceOf[Array[Byte]])
+    // TODO: parse other columns as properties.  For now just skip it
+    FeatureJson(Map(), geom)
+  }
+}

--- a/src/test/scala/com.socrata.tileserver/TestBase.scala
+++ b/src/test/scala/com.socrata.tileserver/TestBase.scala
@@ -24,6 +24,13 @@ trait TestBase
     FeatureJson(attributesAsJvalues, point(pt))
   }
 
+  def feature(ptct: (gen.Points.ValidPoint, Int)): Feature = {
+    import gen.Points._
+
+    val (pt, ct) = ptct
+    feature(pt, count=ct)
+  }
+
   def feature(pt: (Int, Int),
               count: Int = 1,
               attributes: Map[String, String] = Map.empty): Feature = {
@@ -32,8 +39,6 @@ trait TestBase
   }
 
   def encode(s: String): String = JString(s).toString
-
-  def uniq(objs: AnyRef*): Boolean = Set(objs: _*).size == objs.size
 
   def point(pt: (Int, Int)): Point = {
     val (x, y) = pt

--- a/src/test/scala/com.socrata.tileserver/mocks/BinaryResponse.scala
+++ b/src/test/scala/com.socrata.tileserver/mocks/BinaryResponse.scala
@@ -1,0 +1,27 @@
+package com.socrata.tileserver.mocks
+
+import java.io.{InputStream, ByteArrayOutputStream, DataOutputStream}
+import javax.servlet.http.HttpServletResponse.{SC_OK => ScOk}
+import org.velvia.MsgPack
+
+import com.socrata.http.common.util.Acknowledgeable
+
+class BinaryResponse(val payload: Array[Byte],
+                     override val resultCode: Int = ScOk) extends EmptyResponse("application/octet-stream") {
+  override def inputStream(maxBetween: Long): InputStream with Acknowledgeable =
+    ByteInputStream(payload)
+}
+
+object BinaryResponse {
+  def apply(payload: Array[Byte], resultCode: Int = ScOk): BinaryResponse =
+    new BinaryResponse(payload, resultCode)
+  // Below is for quickly generating binary SoQLPack
+  def apply(header: Map[String, Any], rows: Seq[Seq[Any]]): BinaryResponse = {
+    val baos = new ByteArrayOutputStream
+    val dos = new DataOutputStream(baos)
+    MsgPack.pack(header, dos)
+    rows.foreach(MsgPack.pack(_, dos))
+    dos.flush()
+    new BinaryResponse(baos.toByteArray)
+  }
+}

--- a/src/test/scala/com.socrata.tileserver/mocks/ByteInputStream.scala
+++ b/src/test/scala/com.socrata.tileserver/mocks/ByteInputStream.scala
@@ -4,9 +4,9 @@ import java.io.{ByteArrayInputStream, InputStream}
 
 import com.socrata.http.common.util.Acknowledgeable
 
-case class ByteInputStream(bytes: Array[Byte]) extends InputStream with Acknowledgeable {
-  val underlying = new ByteArrayInputStream(bytes)
-
-  override def acknowledge(): Unit = ()
-  override def read(): Int = underlying.read
+object ByteInputStream {
+  def apply(bytes: Array[Byte]): InputStream with Acknowledgeable =
+    new ByteArrayInputStream(bytes) with Acknowledgeable {
+      override def acknowledge(): Unit = ()
+    }
 }

--- a/src/test/scala/com.socrata.tileserver/mocks/ByteInputStream.scala
+++ b/src/test/scala/com.socrata.tileserver/mocks/ByteInputStream.scala
@@ -1,0 +1,12 @@
+package com.socrata.tileserver.mocks
+
+import java.io.{ByteArrayInputStream, InputStream}
+
+import com.socrata.http.common.util.Acknowledgeable
+
+case class ByteInputStream(bytes: Array[Byte]) extends InputStream with Acknowledgeable {
+  val underlying = new ByteArrayInputStream(bytes)
+
+  override def acknowledge(): Unit = ()
+  override def read(): Int = underlying.read
+}

--- a/src/test/scala/com.socrata.tileserver/services/TileServiceTest.scala
+++ b/src/test/scala/com.socrata.tileserver/services/TileServiceTest.scala
@@ -60,11 +60,12 @@ class TileServiceTest extends TestBase with UnusedSugar with MockitoSugar {
         mock[Response]
       }
 
-      TileService(client).geoJsonQuery(reqId,
-                                       request,
-                                       id,
-                                       Map(param),
-                                       Unused): Unit
+      TileService(client).pointQuery(reqId,
+                                     request,
+                                     id,
+                                     Map(param),
+                                     false,
+                                     Unused): Unit
     }
   }
 

--- a/src/test/scala/com.socrata.tileserver/services/TileServiceTest.scala
+++ b/src/test/scala/com.socrata.tileserver/services/TileServiceTest.scala
@@ -460,12 +460,12 @@ class TileServiceTest extends TestBase with UnusedSugar with MockitoSugar {
   }
 
   test("An empty list of coordinates rolls up correctly") {
-    TileService.rollup(Unused, Seq.empty) must be (Set.empty)
+    TileService.rollup(Unused, Iterator.empty) must be (Set.empty)
   }
 
   test("A single coordinate rolls up correctly") {
     forAll { pt: (Int, Int) =>
-      TileService.rollup(Unused, Seq(fJson(pt))) must equal (Set(feature(pt)))
+      TileService.rollup(Unused, Iterator.single(fJson(pt))) must equal (Set(feature(pt)))
     }
   }
 
@@ -478,7 +478,7 @@ class TileServiceTest extends TestBase with UnusedSugar with MockitoSugar {
         val expected = Set(feature(pt0),
                            feature(pt1),
                            feature(pt2))
-        val actual = TileService.rollup(Unused, coordinates)
+        val actual = TileService.rollup(Unused, coordinates.toIterator)
 
         actual must equal (expected)
       }
@@ -496,7 +496,7 @@ class TileServiceTest extends TestBase with UnusedSugar with MockitoSugar {
         val expected = Set(feature(pt0, count=1),
                            feature(pt1, count=2),
                            feature(pt2, count=2))
-        val actual = TileService.rollup(Unused, coordinates)
+        val actual = TileService.rollup(Unused, coordinates.toIterator)
 
         actual must equal (expected)
       }
@@ -522,7 +522,7 @@ class TileServiceTest extends TestBase with UnusedSugar with MockitoSugar {
                            feature(pt0, 1, Map(prop1)),
                            feature(pt1, 2, Map(prop1)))
 
-        val actual = TileService.rollup(Unused, coordinates)
+        val actual = TileService.rollup(Unused, coordinates.toIterator)
 
         actual must equal (expected)
       }

--- a/src/test/scala/com.socrata.tileserver/services/TileServiceTest.scala
+++ b/src/test/scala/com.socrata.tileserver/services/TileServiceTest.scala
@@ -154,6 +154,23 @@ class TileServiceTest extends TestBase with UnusedSugar with MockitoSugar {
     }
   }
 
+  test("Invalid SoQLPack returns 'internal server error' when processing response") {
+    import gen.Extensions._
+
+    forAll { (message: String, ext: Extension) =>
+      val upstream = mocks.BinaryResponse(message.getBytes)
+      val outputStream = new mocks.ByteArrayServletOutputStream
+      val resp = outputStream.responseFor
+
+      TileService(Unused).processResponse(Unused, ext)(upstream)(resp)
+
+      verify(resp).setStatus(ScInternalServerError)
+
+      outputStream.getLowStr must include ("unable to parse binary stream")
+    }
+
+  }
+
   test("Unknown errors are handled when processing response") {
     import gen.Extensions._
 


### PR DESCRIPTION
- Informal tests show .soqlpack-based requests from Core use less than 1/10th the memory of .geojson requests and are 2-3x faster.
- Tests don't pass yet
- .soqlpack only used when only the point column is selected;  $select=xxx results in .geojson being used as a fallback