### PR TITLE
Get binary SoQLPack point ingestion working

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ libraryDependencies ++= Seq(
   "commons-codec"            % "commons-codec"            % "1.10",
   "commons-io"               % "commons-io"               % "2.4",
   "no.ecc.vectortile"        % "java-vector-tile"         % "1.0.1",
-  "org.velvia"              %% "msgpack4s"                % "0.4.2",
+  "org.velvia"              %% "msgpack4s"                % "0.4.3",
   "org.apache.curator"       % "curator-x-discovery"      % "2.7.0"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,8 @@ scalaVersion := "2.10.4"
 
 resolvers ++= Seq(
   "socrata maven" at "https://repository-socrata-oss.forge.cloudbees.com/release",
-  "ecc" at "https://github.com/ElectronicChartCentre/ecc-mvn-repo/raw/master/releases"
+  "ecc" at "https://github.com/ElectronicChartCentre/ecc-mvn-repo/raw/master/releases",
+  "velvia maven" at "http://dl.bintray.com/velvia/maven"
 )
 
 libraryDependencies ++= Seq(
@@ -17,6 +18,7 @@ libraryDependencies ++= Seq(
   "commons-codec"            % "commons-codec"            % "1.10",
   "commons-io"               % "commons-io"               % "2.4",
   "no.ecc.vectortile"        % "java-vector-tile"         % "1.0.1",
+  "org.velvia"              %% "msgpack4s"                % "0.4.2",
   "org.apache.curator"       % "curator-x-discovery"      % "2.7.0"
 )
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -8,7 +8,7 @@ com.socrata {
 
     threadpool {
       min-threads = 3
-      max-threads = 5
+      max-threads = 30
       idle-timeout = 30 s
       queue-length = 100
     }

--- a/src/main/scala/com.socrata.tileserver/exceptions/InvalidSoqlPackException.scala
+++ b/src/main/scala/com.socrata.tileserver/exceptions/InvalidSoqlPackException.scala
@@ -1,0 +1,11 @@
+package com.socrata.tileserver.exceptions
+
+import scala.util.control.NoStackTrace
+
+case class InvalidSoqlPackException(headers: Map[String, Any]) extends NoStackTrace {
+  override val getMessage = if (headers.isEmpty) {
+    "Unable to parse binary stream into SoQLPack/MessagePack records"
+  } else {
+    s"No geometry present or other header error: $headers"
+  }
+}

--- a/src/main/scala/com.socrata.tileserver/services/TileService.scala
+++ b/src/main/scala/com.socrata.tileserver/services/TileService.scala
@@ -16,7 +16,6 @@ import com.rojoma.json.v3.io.JsonReader
 import com.rojoma.json.v3.io.JsonReaderException
 import com.rojoma.simplearm.v2.{using, ResourceScope}
 import com.vividsolutions.jts.geom.GeometryFactory
-import com.vividsolutions.jts.io.WKBReader
 import org.apache.commons.io.IOUtils
 import org.slf4j.{Logger, LoggerFactory, MDC}
 import org.velvia.MsgPackUtils._
@@ -173,8 +172,6 @@ object TileService {
                             HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
                             HttpServletResponse.SC_NOT_IMPLEMENTED,
                             HttpServletResponse.SC_SERVICE_UNAVAILABLE)
-  private val reader = new WKBReader
-
   private[services] def echoResponse(resp: Response): HttpResponse = {
     val jValue =
       Try(JsonReader.fromString(IOUtils.toString(resp.inputStream(), UTF_8)))
@@ -228,7 +225,7 @@ object TileService {
       val jsonHeaders = JObject(headers.mapValues(v => JString(v.toString)))
       headers.asInt("geometry_index") match {
         case geomIndex if geomIndex < 0 => Failure(InvalidSoqlPackException(headers))
-        case geomIndex => Success(jsonHeaders -> new FeatureJsonIterator(reader, dis, geomIndex))
+        case geomIndex => Success(jsonHeaders -> new FeatureJsonIterator(dis, geomIndex))
       }
     } catch {
       case _: InvalidMsgPackDataException => Failure(InvalidSoqlPackException(Map.empty))

--- a/src/main/scala/com.socrata.tileserver/services/TileService.scala
+++ b/src/main/scala/com.socrata.tileserver/services/TileService.scala
@@ -16,6 +16,7 @@ import com.rojoma.json.v3.io.JsonReader
 import com.rojoma.json.v3.io.JsonReaderException
 import com.rojoma.simplearm.v2.{using, ResourceScope}
 import com.vividsolutions.jts.geom.GeometryFactory
+import com.vividsolutions.jts.io.ParseException
 import org.apache.commons.io.IOUtils
 import org.slf4j.{Logger, LoggerFactory, MDC}
 import org.velvia.MsgPackUtils._
@@ -77,6 +78,10 @@ case class TileService(client: CuratedServiceClient) extends SimpleResource {
       fatal("Invalid JSON returned from underlying service", readerEx)
     case geoJsonEx: InvalidGeoJsonException =>
       fatal("Invalid Geo-JSON returned from underlying service", geoJsonEx)
+    case soqlPackEx: InvalidSoqlPackException =>
+      fatal("Invalid SoQLPack returned from underlying service", soqlPackEx)
+    case jtsEx: ParseException =>
+      fatal("Invalid WKB geometry returned from underlying service", jtsEx)
     case unknown =>
       fatal("Unknown error", unknown)
   }

--- a/src/main/scala/com.socrata.tileserver/services/TileService.scala
+++ b/src/main/scala/com.socrata.tileserver/services/TileService.scala
@@ -9,7 +9,7 @@ import javax.servlet.http.HttpServletResponse.{SC_NOT_MODIFIED => ScNotModified}
 import javax.servlet.http.HttpServletResponse.{SC_OK => ScOk}
 import scala.util.{Try, Success, Failure}
 
-import com.rojoma.json.v3.ast.{JValue, JNull}
+import com.rojoma.json.v3.ast._
 import com.rojoma.json.v3.codec.JsonEncode.toJValue
 import com.rojoma.json.v3.interpolation._
 import com.rojoma.json.v3.io.JsonReader
@@ -225,9 +225,10 @@ object TileService {
 
     try {
       val headers = MsgPack.unpack(dis, MsgPack.UNPACK_RAW_AS_STRING).asInstanceOf[Map[String, Any]]
+      val jsonHeaders = JObject(headers.mapValues(v => JString(v.toString)))
       headers.asInt("geometry_index") match {
         case geomIndex if geomIndex < 0 => Failure(InvalidSoqlPackException(headers))
-        case geomIndex => Success(JNull -> new FeatureJsonIterator(reader, dis, geomIndex))
+        case geomIndex => Success(jsonHeaders -> new FeatureJsonIterator(reader, dis, geomIndex))
       }
     } catch {
       case _: InvalidMsgPackDataException => Failure(InvalidSoqlPackException(Map.empty))

--- a/src/main/scala/com.socrata.tileserver/util/FeatureJsonIterator.scala
+++ b/src/main/scala/com.socrata.tileserver/util/FeatureJsonIterator.scala
@@ -1,0 +1,21 @@
+package com.socrata.tileserver
+package util
+
+import java.io.DataInputStream
+
+import com.socrata.thirdparty.geojson.FeatureJson
+import com.vividsolutions.jts.io.WKBReader
+import org.velvia.MsgPack
+import org.velvia.MsgPackUtils._
+
+class FeatureJsonIterator(reader: WKBReader,
+                          dis: DataInputStream,
+                          geomIndex: Int) extends Iterator[FeatureJson] {
+  def hasNext: Boolean = dis.available > 0
+  def next(): FeatureJson = {
+    val row = MsgPack.unpack(dis, 0).asInstanceOf[Seq[Any]]
+    val geom = reader.read(row(geomIndex).asInstanceOf[Array[Byte]])
+    // TODO: parse other columns as properties.  For now just skip it
+    FeatureJson(Map(), geom)
+  }
+}

--- a/src/main/scala/com.socrata.tileserver/util/FeatureJsonIterator.scala
+++ b/src/main/scala/com.socrata.tileserver/util/FeatureJsonIterator.scala
@@ -15,10 +15,10 @@ import org.velvia.MsgPackUtils._
  * Note that there is no good way to detect the end of a stream, other than to try reading from
  * it in hasNext and cache the results.....
  */
-class FeatureJsonIterator(reader: WKBReader,
-                          dis: DataInputStream,
+class FeatureJsonIterator(dis: DataInputStream,
                           geomIndex: Int) extends Iterator[FeatureJson] {
   private val logger = LoggerFactory.getLogger(getClass)
+  private val reader = new WKBReader
 
   var nextRow: Option[Seq[Any]] = None
   var rowNum = 0

--- a/src/main/scala/com.socrata.tileserver/util/FeatureJsonIterator.scala
+++ b/src/main/scala/com.socrata.tileserver/util/FeatureJsonIterator.scala
@@ -5,15 +5,43 @@ import java.io.DataInputStream
 
 import com.socrata.thirdparty.geojson.FeatureJson
 import com.vividsolutions.jts.io.WKBReader
-import org.velvia.MsgPack
+import org.slf4j.LoggerFactory
+import org.velvia.{MsgPack, InvalidMsgPackDataException}
 import org.velvia.MsgPackUtils._
 
+/**
+ * An Iterator that streams in FeatureJson's from a SoQLPack binary stream.
+ * Note that there is no good way to detect the end of a stream, other than to try reading from
+ * it in hasNext and cache the results.....
+ */
 class FeatureJsonIterator(reader: WKBReader,
                           dis: DataInputStream,
                           geomIndex: Int) extends Iterator[FeatureJson] {
-  def hasNext: Boolean = dis.available > 0
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  var nextRow: Option[Seq[Any]] = None
+
+  logger.info("Created FeatureIterator")
+
+  // Only allow nextRow to be filled once
+  // NOTE: if IOException is raised during this, make sure the stream hasn't been closed prior
+  // to reading from it.
+  def hasNext: Boolean = {
+    if (!nextRow.isDefined) {
+      try {
+        nextRow = Some(MsgPack.unpack(dis, 0).asInstanceOf[Seq[Any]])
+      } catch {
+        case e: InvalidMsgPackDataException =>
+          logger.info("Probably reached end of data, got " + e)
+          nextRow = None
+      }
+    }
+    nextRow.isDefined
+  }
+
   def next(): FeatureJson = {
-    val row = MsgPack.unpack(dis, 0).asInstanceOf[Seq[Any]]
+    val row = nextRow.get
+    nextRow = None    // MUST reset to avoid an endless loop
     val geom = reader.read(row(geomIndex).asInstanceOf[Array[Byte]])
     // TODO: parse other columns as properties.  For now just skip it
     FeatureJson(Map(), geom)

--- a/src/test/scala/com.socrata.tileserver/TestBase.scala
+++ b/src/test/scala/com.socrata.tileserver/TestBase.scala
@@ -24,6 +24,13 @@ trait TestBase
     FeatureJson(attributesAsJvalues, point(pt))
   }
 
+  def feature(ptct: (gen.Points.ValidPoint, Int)): Feature = {
+    import gen.Points._
+
+    val (pt, ct) = ptct
+    feature(pt, count=ct)
+  }
+
   def feature(pt: (Int, Int),
               count: Int = 1,
               attributes: Map[String, String] = Map.empty): Feature = {
@@ -32,8 +39,6 @@ trait TestBase
   }
 
   def encode(s: String): String = JString(s).toString
-
-  def uniq(objs: AnyRef*): Boolean = Set(objs: _*).size == objs.size
 
   def point(pt: (Int, Int)): Point = {
     val (x, y) = pt

--- a/src/test/scala/com.socrata.tileserver/TestBase.scala
+++ b/src/test/scala/com.socrata.tileserver/TestBase.scala
@@ -58,5 +58,5 @@ trait TestBase
   // If need be rename to includeSlice.
   def includeSlice[T](expected: Array[T]): Matcher[Array[T]] = new ArraySliceIncludeMatcher(expected)
 
-  override def afterAll = UnusedSugar.rs.close()
+  override def afterAll: Unit = UnusedSugar.rs.close()
 }

--- a/src/test/scala/com.socrata.tileserver/TestBase.scala
+++ b/src/test/scala/com.socrata.tileserver/TestBase.scala
@@ -15,7 +15,8 @@ import util.TileEncoder.Feature
 trait TestBase
     extends FunSuite
     with org.scalatest.MustMatchers
-    with PropertyChecks {
+    with PropertyChecks
+    with BeforeAndAfterAll {
   val GeomFactory = new GeometryFactory()
 
   def fJson(pt: (Int, Int),
@@ -56,4 +57,6 @@ trait TestBase
 
   // If need be rename to includeSlice.
   def includeSlice[T](expected: Array[T]): Matcher[Array[T]] = new ArraySliceIncludeMatcher(expected)
+
+  override def afterAll = UnusedSugar.rs.close()
 }

--- a/src/test/scala/com.socrata.tileserver/UnusedSugar.scala
+++ b/src/test/scala/com.socrata.tileserver/UnusedSugar.scala
@@ -2,11 +2,12 @@ package com.socrata.tileserver
 
 import scala.language.implicitConversions
 
+import com.rojoma.simplearm.v2.ResourceScope
 import org.mockito.Mockito.mock
 
-import com.socrata.thirdparty.curator.CuratedServiceClient
 import com.socrata.http.client.Response
 import com.socrata.http.server.{HttpRequest, HttpResponse}
+import com.socrata.thirdparty.curator.CuratedServiceClient
 
 trait UnusedSugar {
   trait UnusedValue
@@ -27,4 +28,5 @@ trait UnusedSugar {
   // Can't be Map[K, V] because then it matches K => V.
   implicit def unusedToMap[T](u: UnusedValue): Map[String, T] = Map.empty
   implicit def unusedToSet[T](u: UnusedValue): Set[T] = Set.empty
+  implicit def unusedToResourceScope(u: UnusedValue): ResourceScope = new ResourceScope()
 }

--- a/src/test/scala/com.socrata.tileserver/UnusedSugar.scala
+++ b/src/test/scala/com.socrata.tileserver/UnusedSugar.scala
@@ -28,5 +28,10 @@ trait UnusedSugar {
   // Can't be Map[K, V] because then it matches K => V.
   implicit def unusedToMap[T](u: UnusedValue): Map[String, T] = Map.empty
   implicit def unusedToSet[T](u: UnusedValue): Set[T] = Set.empty
-  implicit def unusedToResourceScope(u: UnusedValue): ResourceScope = new ResourceScope()
+
+  implicit def unusedToResourceScope(u: UnusedValue): ResourceScope = UnusedSugar.rs
+}
+
+object UnusedSugar {
+  val rs = new ResourceScope()
 }

--- a/src/test/scala/com.socrata.tileserver/mocks/BinaryResponse.scala
+++ b/src/test/scala/com.socrata.tileserver/mocks/BinaryResponse.scala
@@ -16,12 +16,18 @@ object BinaryResponse {
   def apply(payload: Array[Byte], resultCode: Int = ScOk): BinaryResponse =
     new BinaryResponse(payload, resultCode)
   // Below is for quickly generating binary SoQLPack
-  def apply(header: Map[String, Any], rows: Seq[Seq[Any]]): BinaryResponse = {
+  def apply(header: Map[String, Any], rows: Seq[Seq[Any]],
+            junk: Option[Array[Byte]]): BinaryResponse = {
     val baos = new ByteArrayOutputStream
     val dos = new DataOutputStream(baos)
     MsgPack.pack(header, dos)
     rows.foreach(MsgPack.pack(_, dos))
+    // Now write a junk row to test parsing errors
+    junk foreach { junkBytes => MsgPack.pack(Seq(junkBytes), dos) }
     dos.flush()
     new BinaryResponse(baos.toByteArray)
   }
+
+  def apply(header: Map[String, Any], rows: Seq[Seq[Any]]): BinaryResponse =
+    apply(header, rows, None)
 }

--- a/src/test/scala/com.socrata.tileserver/mocks/BinaryResponse.scala
+++ b/src/test/scala/com.socrata.tileserver/mocks/BinaryResponse.scala
@@ -1,0 +1,27 @@
+package com.socrata.tileserver.mocks
+
+import java.io.{InputStream, ByteArrayOutputStream, DataOutputStream}
+import javax.servlet.http.HttpServletResponse.{SC_OK => ScOk}
+import org.velvia.MsgPack
+
+import com.socrata.http.common.util.Acknowledgeable
+
+class BinaryResponse(val payload: Array[Byte],
+                     override val resultCode: Int = ScOk) extends EmptyResponse("application/octet-stream") {
+  override def inputStream(maxBetween: Long): InputStream with Acknowledgeable =
+    ByteInputStream(payload)
+}
+
+object BinaryResponse {
+  def apply(payload: Array[Byte], resultCode: Int = ScOk): BinaryResponse =
+    new BinaryResponse(payload, resultCode)
+  // Below is for quickly generating binary SoQLPack
+  def apply(header: Map[String, Any], rows: Seq[Seq[Any]]): BinaryResponse = {
+    val baos = new ByteArrayOutputStream
+    val dos = new DataOutputStream(baos)
+    MsgPack.pack(header, dos)
+    rows.foreach(MsgPack.pack(_, dos))
+    dos.flush()
+    new BinaryResponse(baos.toByteArray)
+  }
+}

--- a/src/test/scala/com.socrata.tileserver/mocks/ByteInputStream.scala
+++ b/src/test/scala/com.socrata.tileserver/mocks/ByteInputStream.scala
@@ -1,0 +1,12 @@
+package com.socrata.tileserver.mocks
+
+import java.io.{ByteArrayInputStream, InputStream}
+
+import com.socrata.http.common.util.Acknowledgeable
+
+object ByteInputStream {
+  def apply(bytes: Array[Byte]): InputStream with Acknowledgeable =
+    new ByteArrayInputStream(bytes) with Acknowledgeable {
+      override def acknowledge(): Unit = ()
+    }
+}

--- a/src/test/scala/com.socrata.tileserver/services/TileServiceTest.scala
+++ b/src/test/scala/com.socrata.tileserver/services/TileServiceTest.scala
@@ -11,6 +11,7 @@ import scala.util.{Failure, Success}
 
 import com.rojoma.json.v3.ast.{JValue, JNull}
 import com.rojoma.json.v3.interpolation._
+import com.rojoma.simplearm.v2.{using, ResourceScope}
 import com.socrata.http.server.util.RequestId.{RequestId, ReqIdHeader}
 import com.vividsolutions.jts.io.WKBWriter
 import org.mockito.Matchers.anyInt
@@ -84,7 +85,7 @@ class TileServiceTest extends TestBase with UnusedSugar with MockitoSugar {
       val upstream = mocks.HeaderResponse(Map(known, unknown))
       val resp = new mocks.ByteArrayServletOutputStream().responseFor
 
-      TileService(Unused).processResponse(Unused, ext)(upstream)(resp)
+      TileService(Unused).processResponse(Unused, ext, Unused)(upstream)(resp)
 
       verify(resp).setStatus(ScOk)
       verify(resp).setHeader("Access-Control-Allow-Origin", "*")
@@ -102,7 +103,7 @@ class TileServiceTest extends TestBase with UnusedSugar with MockitoSugar {
       val outputStream = new mocks.ByteArrayServletOutputStream
       val resp = outputStream.responseFor
 
-      TileService(Unused).processResponse(Unused, ext)(upstream)(resp)
+      TileService(Unused).processResponse(Unused, ext, Unused)(upstream)(resp)
 
       verify(resp).setStatus(ScOk)
 
@@ -127,7 +128,7 @@ class TileServiceTest extends TestBase with UnusedSugar with MockitoSugar {
       val outputStream = new mocks.ByteArrayServletOutputStream
       val resp = outputStream.responseFor
 
-      TileService(Unused).processResponse(Unused, ext)(upstream)(resp)
+      TileService(Unused).processResponse(Unused, ext, Unused)(upstream)(resp)
 
       verify(resp).setStatus(ScInternalServerError)
 
@@ -146,7 +147,7 @@ class TileServiceTest extends TestBase with UnusedSugar with MockitoSugar {
       val outputStream = new mocks.ByteArrayServletOutputStream
       val resp = outputStream.responseFor
 
-      TileService(Unused).processResponse(Unused, ext)(upstream)(resp)
+      TileService(Unused).processResponse(Unused, ext, Unused)(upstream)(resp)
 
       verify(resp).setStatus(ScInternalServerError)
 
@@ -166,7 +167,7 @@ class TileServiceTest extends TestBase with UnusedSugar with MockitoSugar {
       val outputStream = new mocks.ByteArrayServletOutputStream
       val resp = outputStream.responseFor
 
-      TileService(Unused).processResponse(Unused, ext)(upstream)(resp)
+      TileService(Unused).processResponse(Unused, ext, Unused)(upstream)(resp)
 
       verify(resp).setStatus(ScInternalServerError)
 
@@ -547,7 +548,7 @@ class TileServiceTest extends TestBase with UnusedSugar with MockitoSugar {
 
       val expected = Success(JNull -> Iterator.empty)
 
-      TileService(Unused).processResponse(Unused, ext)(upstream)(resp)
+      TileService(Unused).processResponse(Unused, ext, Unused)(upstream)(resp)
 
       // TODO: Figure out asserts.
     }
@@ -567,15 +568,17 @@ class TileServiceTest extends TestBase with UnusedSugar with MockitoSugar {
 
       val upstream = mocks.BinaryResponse(Map("geometry_index" -> 0), rows)
 
-      val maybeResult = TileService.soqlUnpackFeatures(upstream)
-      maybeResult must be a ('success)
+      using(new ResourceScope()) { rs =>
+        val maybeResult = TileService.soqlUnpackFeatures(rs)(upstream)
+        maybeResult must be a ('success)
 
-      val (jVal, iter) = maybeResult.get
-      val features = iter.toSeq
+        val (jVal, iter) = maybeResult.get
+        val features = iter.toSeq
 
-      jVal must equal (JNull)
-      features must have length (pts.size)
-      features must equal (pts.map(fJson(_)))
+        jVal must equal (JNull)
+        features must have length (pts.size)
+        features must equal (pts.map(fJson(_)))
+      }
     }
   }
 
@@ -589,7 +592,7 @@ class TileServiceTest extends TestBase with UnusedSugar with MockitoSugar {
       val outputStream = new mocks.ByteArrayServletOutputStream
       val resp = outputStream.responseFor
 
-      TileService(Unused).processResponse(Unused, ext)(upstream)(resp)
+      TileService(Unused).processResponse(Unused, ext, Unused)(upstream)(resp)
 
       verify(resp).setStatus(ScInternalServerError)
 
@@ -609,7 +612,7 @@ class TileServiceTest extends TestBase with UnusedSugar with MockitoSugar {
       val outputStream = new mocks.ByteArrayServletOutputStream
       val resp = outputStream.responseFor
 
-      TileService(Unused).processResponse(Unused, ext)(upstream)(resp)
+      TileService(Unused).processResponse(Unused, ext, Unused)(upstream)(resp)
 
       verify(resp).setStatus(ScInternalServerError)
 
@@ -628,7 +631,7 @@ class TileServiceTest extends TestBase with UnusedSugar with MockitoSugar {
 
         val expected = Success(JNull -> Iterator.empty)
 
-        TileService(Unused).processResponse(Unused, ext)(upstream)(resp)
+        TileService(Unused).processResponse(Unused, ext, Unused)(upstream)(resp)
 
         verify(resp).setStatus(ScInternalServerError)
 

--- a/src/test/scala/com.socrata.tileserver/services/TileServiceTest.scala
+++ b/src/test/scala/com.socrata.tileserver/services/TileServiceTest.scala
@@ -7,17 +7,21 @@ import javax.servlet.http.HttpServletResponse.{SC_INTERNAL_SERVER_ERROR => ScInt
 import javax.servlet.http.HttpServletResponse.{SC_NOT_MODIFIED => ScNotModified}
 import javax.servlet.http.HttpServletResponse.{SC_OK => ScOk}
 import scala.util.control.NoStackTrace
+import scala.util.{Failure, Success}
 
+import com.rojoma.json.v3.ast.{JValue, JNull}
 import com.rojoma.json.v3.interpolation._
 import com.socrata.http.server.util.RequestId.{RequestId, ReqIdHeader}
+import com.vividsolutions.jts.io.WKBWriter
 import org.mockito.Matchers.anyInt
 import org.mockito.Mockito.{verify, when}
 import org.scalatest.mock.MockitoSugar
 
 import com.socrata.http.client.{RequestBuilder, Response}
+import com.socrata.http.server.HttpRequest
 import com.socrata.http.server.HttpRequest.AugmentedHttpServletRequest
 import com.socrata.http.server.routing.TypedPathComponent
-import com.socrata.http.server.HttpRequest
+import com.socrata.thirdparty.geojson.FeatureJson
 
 import util.TileEncoder
 
@@ -60,11 +64,12 @@ class TileServiceTest extends TestBase with UnusedSugar with MockitoSugar {
         mock[Response]
       }
 
-      TileService(client).geoJsonQuery(reqId,
-                                       request,
-                                       id,
-                                       Map(param),
-                                       Unused): Unit
+      TileService(client).pointQuery(reqId,
+                                     request,
+                                     id,
+                                     Map(param),
+                                     false,
+                                     Unused): Unit
     }
   }
 
@@ -460,52 +465,53 @@ class TileServiceTest extends TestBase with UnusedSugar with MockitoSugar {
   }
 
   test("An empty list of coordinates rolls up correctly") {
-    TileService.rollup(Unused, Seq.empty) must be (Set.empty)
+    TileService.rollup(Unused, Iterator.empty) must be (Set.empty)
   }
 
   test("A single coordinate rolls up correctly") {
-    forAll { pt: (Int, Int) =>
-      TileService.rollup(Unused, Seq(fJson(pt))) must equal (Set(feature(pt)))
+    import gen.Points._
+
+    forAll { pt: ValidPoint =>
+      TileService.rollup(Unused, Iterator.single(fJson(pt))) must equal (Set(feature(pt)))
     }
   }
 
   test("Unique coordinates are included when rolled up") {
-    forAll { (pt0: (Int, Int), pt1: (Int, Int), pt2: (Int, Int)) =>
-      whenever (uniq(pt0, pt1, pt2)) {
-        val coordinates = Seq(fJson(pt0),
-                              fJson(pt1),
-                              fJson(pt2))
-        val expected = Set(feature(pt0),
-                           feature(pt1),
-                           feature(pt2))
-        val actual = TileService.rollup(Unused, coordinates)
+    import gen.Points._
 
-        actual must equal (expected)
-      }
+    forAll { pts: Set[ValidPoint] =>
+      val coordinates = pts.map(fJson(_))
+      val expected = pts.map(feature(_))
+      val actual = TileService.rollup(Unused, coordinates.toIterator)
+
+      actual must equal (expected)
     }
   }
 
   test("Coordinates have correct counts when rolled up") {
-    forAll { (pt0: (Int, Int), pt1: (Int, Int), pt2: (Int, Int)) =>
-      whenever (uniq(pt0, pt1, pt2)) {
-        val coordinates = Seq(fJson(pt0),
-                              fJson(pt1),
-                              fJson(pt1),
-                              fJson(pt2),
-                              fJson(pt2))
-        val expected = Set(feature(pt0, count=1),
-                           feature(pt1, count=2),
-                           feature(pt2, count=2))
-        val actual = TileService.rollup(Unused, coordinates)
+    import gen.Points._
 
-        actual must equal (expected)
-      }
+    forAll { uniquePts: Set[ValidPoint] =>
+      val pts = uniquePts.toSeq
+      val dupes = pts ++
+        (if (pts.isEmpty) pts else pts(0) +: Seq(pts(pts.length - 1)))
+
+      val coordinates = dupes.map(fJson(_))
+      val expected = dupes.
+        groupBy(identity).
+        mapValues(_.size).map(feature(_)).toSet
+
+      val actual = TileService.rollup(Unused, coordinates.toIterator)
+
+      actual must equal (expected)
     }
   }
 
   test("Coordinates with unique properties are not rolled up") {
-    forAll { (pt0: (Int, Int),
-              pt1: (Int, Int),
+    import gen.Points._
+
+    forAll { (pt0: ValidPoint,
+              pt1: ValidPoint,
               prop0: (String, String),
               prop1: (String, String)) =>
       val (k0, _) = prop0
@@ -522,9 +528,111 @@ class TileServiceTest extends TestBase with UnusedSugar with MockitoSugar {
                            feature(pt0, 1, Map(prop1)),
                            feature(pt1, 2, Map(prop1)))
 
-        val actual = TileService.rollup(Unused, coordinates)
+        val actual = TileService.rollup(Unused, coordinates.toIterator)
 
         actual must equal (expected)
+      }
+    }
+  }
+
+
+
+  test("An empty message is successfully unpacked") {
+    import gen.Extensions._
+
+    forAll { (ext: Extension) =>
+      val upstream = mocks.BinaryResponse(Map("geometry_index" -> 0), Seq.empty)
+      val outputStream = new mocks.ByteArrayServletOutputStream
+      val resp = outputStream.responseFor
+
+      val expected = Success(JNull -> Iterator.empty)
+
+      TileService(Unused).processResponse(Unused, ext)(upstream)(resp)
+
+      // TODO: Figure out asserts.
+    }
+  }
+
+  test("Features are successfully unpacked") {
+    import gen.Extensions._
+    import gen.Points._
+
+    val writer = new WKBWriter()
+
+    forAll { pts: Seq[ValidPoint] =>
+      val rows = pts.map { pt =>
+        val (geom, props) = feature(pt)
+        Seq(writer.write(geom))
+      }
+
+      val upstream = mocks.BinaryResponse(Map("geometry_index" -> 0), rows)
+
+      val maybeResult = TileService.soqlUnpackFeatures(upstream)
+      maybeResult must be a ('success)
+
+      val (jVal, iter) = maybeResult.get
+      val features = iter.toSeq
+
+      jVal must equal (JNull)
+      features must have length (pts.size)
+      features must equal (pts.map(fJson(_)))
+    }
+  }
+
+  test("TODO: features are unpacked with properties") (pending)
+
+  test("Invalid headers are rejected when unpacking") {
+    import gen.Extensions._
+
+    forAll { (payload: Array[Byte], ext: Extension) =>
+      val upstream = mocks.BinaryResponse(payload)
+      val outputStream = new mocks.ByteArrayServletOutputStream
+      val resp = outputStream.responseFor
+
+      TileService(Unused).processResponse(Unused, ext)(upstream)(resp)
+
+      verify(resp).setStatus(ScInternalServerError)
+
+      outputStream.getLowStr must include ("unable to parse binary stream")
+    }
+  }
+
+  test("Message pack null is rejected when unpacking") {
+    import gen.Extensions._
+
+    // scalastyle:off magic.number
+    val msgNull: Array[Byte] = Array(-64)
+    // scalastyle:on magic.number
+
+    forAll { ext: Extension =>
+      val upstream = mocks.BinaryResponse(msgNull)
+      val outputStream = new mocks.ByteArrayServletOutputStream
+      val resp = outputStream.responseFor
+
+      TileService(Unused).processResponse(Unused, ext)(upstream)(resp)
+
+      verify(resp).setStatus(ScInternalServerError)
+
+      outputStream.getLowStr must include ("unable to parse binary stream")
+    }
+  }
+
+  test("Invalid `geometry_index`s are rejected when unpacking") {
+    import gen.Extensions._
+
+    forAll { (idx: Int, ext: Extension) =>
+      whenever (idx < 0) {
+        val upstream = mocks.BinaryResponse(Map("geometry_index" -> -1), Seq.empty)
+        val outputStream = new mocks.ByteArrayServletOutputStream
+        val resp = outputStream.responseFor
+
+        val expected = Success(JNull -> Iterator.empty)
+
+        TileService(Unused).processResponse(Unused, ext)(upstream)(resp)
+
+        verify(resp).setStatus(ScInternalServerError)
+
+        outputStream.getLowStr must include ("header error")
       }
     }
   }


### PR DESCRIPTION
Lots of fixes:
- Use `ResourceScope` to close the stream only when all features had been read
- Proper detection of end of binary stream
- Use local WKBReaders to avoid multithreaded parsing errors
- better instrumentation

I may work on more perf improvements (Evan).